### PR TITLE
Proper behavior when  == latest in Agent and Puppet Reporter packages

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -58,7 +58,7 @@ class opsmatic::agent (
   # the upstart job config doesn't exist anyways so we cannot use a service
   # definition to stop the agent. Instead, we call an exec to kill it.
   case $ensure {
-    'present', 'installed': {
+    'present', 'installed', 'latest': {
       # Configure the agent client certs
       exec { 'opsmatic_agent_initial_configuration':
         command => "/usr/bin/config-opsmatic-agent --token=${token}",

--- a/manifests/puppet_reporter.pp
+++ b/manifests/puppet_reporter.pp
@@ -59,7 +59,7 @@ class opsmatic::puppet_reporter (
   # the upstart job config doesn't exist anyways so we cannot use a service
   # definition to stop the service. Instead, we call an exec to kill it.
   case $ensure {
-    'present', 'installed': {
+    'present', 'installed', 'latest': {
       service { 'opsmatic-puppet-reporter':
         ensure    => 'running',
         enable    => true,


### PR DESCRIPTION
This eliminates the current behavior in which if 'latest' is specified, the actual service is killed.
