### PR TITLE
Add support for file watching in the Opsmatic agent

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -16,8 +16,9 @@
 # Opsmatic Inc. (support@opsmatic.com)
 #
 class opsmatic::agent (
-  $ensure       = $opsmatic::params::agent_ensure,
-  $token        = $opsmatic::params::token,
+  $ensure               = $opsmatic::params::agent_ensure,
+  $token                = $opsmatic::params::token,
+  $files_config_enabled = $opsmatic::params::files_config_enabled,
 ) inherits opsmatic::params {
 
   if $token == '' {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,6 +19,9 @@ class opsmatic::params {
   # Integration token
   $token = ''
 
+  # Enable file watching
+  $files_config_enabled = false
+
   # Paths to ignore by the Opsmatic Gent
   $paths_ignore = []
 

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -23,10 +23,10 @@ describe 'opsmatic::agent', :type => 'class' do
     end
   end
 
-  context 'token => 1234' do
+  context 'token => 1234, files_config_enabled => true' do
     let(:facts) { FACTS }
     let(:params) {{
-      :token => '1234'
+      :token => '1234', :files_config_enabled => true
     }}
     it do
       should compile.with_all_deps
@@ -34,7 +34,7 @@ describe 'opsmatic::agent', :type => 'class' do
       should contain_package('opsmatic-agent').with(
         'ensure' => 'present')
       should contain_file('/etc/opsmatic-agent.conf').with(
-        'content' => /paths_ignore = \[\]/)
+        'content' => /paths_ignore = \[\]\nfiles_config_enabled = true/)
       should contain_exec('opsmatic_agent_initial_configuration').with(
         'command' => '/usr/bin/config-opsmatic-agent --token=1234')
       should contain_service('opsmatic-agent')

--- a/templates/opsmatic-agent.conf.erb
+++ b/templates/opsmatic-agent.conf.erb
@@ -1,2 +1,2 @@
-# This file is managed by Puppet, do not modify by hand.
 paths_ignore = <%= @paths_ignore.inspect %>
+files_config_enabled = <%= @files_config_enabled.inspect %>


### PR DESCRIPTION
This patch enables the manifest to configure the Opsmatic agent to watch files.
